### PR TITLE
Use FullLoader explicitly when loading yaml

### DIFF
--- a/beansdbadmin/core/conf.py
+++ b/beansdbadmin/core/conf.py
@@ -7,12 +7,12 @@ import yaml
 
 def get_server_conf(conf_dir):
     with open(os.path.join(conf_dir, "global.yaml")) as f:
-        gconf = yaml.load(f)
+        gconf = yaml.load(f, Loader=yaml.FullLoader)
 
     localpath = os.path.join(conf_dir, "local.yaml")
     if os.path.exists(localpath):
         with open(localpath) as f:
-            lconf = yaml.load(f)
+            lconf = yaml.load(f, Loader=yaml.FullLoader)
         return update_dict(gconf, lconf)
     else:
         return gconf

--- a/beansdbadmin/core/route.py
+++ b/beansdbadmin/core/route.py
@@ -81,7 +81,7 @@ class Route(object):
 
     @classmethod
     def from_yaml(cls, raw):
-        return Route(yaml.load(raw))
+        return Route(yaml.load(raw, Loader=yaml.FullLoader))
 
     @classmethod
     def from_zk(cls, zk):

--- a/beansdbadmin/core/zkcli.py
+++ b/beansdbadmin/core/zkcli.py
@@ -42,7 +42,7 @@ def check_route(zk, servers, proxies, new_ver):
 def update_zk_from_file(cluster, path):
     zk = ZK(cluster)
     with open(path, 'r') as f:
-        table = yaml.load(f)
+        table = yaml.load(f, Loader=yaml.FullLoader)
         return zk.route_set(yaml.dump(table))
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask==1.0
 libmc==1.1.0
-pyyaml>=4.2b1
+pyyaml>=5.1
 kazoo==2.2.1
 mmh3==2.5.1


### PR DESCRIPTION
> Use of PyYAML's yaml.load function __without specifying the `Loader=...` parameter__, has been deprecated. In PyYAML version 5.1, you will get a warning, but the function will still work.

> `FullLoader`
> Loads the full YAML language. Avoids arbitrary code execution. This is currently (PyYAML 5.1) the default loader called by `yaml.load(input)` (after issuing the warning).

Fix #6 